### PR TITLE
Links redirect to tx by id

### DIFF
--- a/frontend/components/account/index.vue
+++ b/frontend/components/account/index.vue
@@ -10,6 +10,7 @@
       <div class="account-content">
         <FormatAddress
           :value="value"
+          :id="id"
           :icon="icon"
           :length="length"
         />
@@ -29,6 +30,9 @@ export default {
     value: {
       type: String,
       required: true
+    },
+    id: {
+      type: Number
     },
     title: {
       type: String,

--- a/frontend/components/formatAddress/index.vue
+++ b/frontend/components/formatAddress/index.vue
@@ -112,6 +112,9 @@ export default {
       type: String,
       required: true
     },
+    id: {
+      type: Number
+    },
     length: {
       type: String,
       default: 'full'
@@ -134,7 +137,7 @@ export default {
     },
     link () {
       if (this.value.match(/^th_[1-9A-HJ-NP-Za-km-z]{48,50}$/)) {
-        return `/transactions/${this.value}`
+        return `/transactions/${this.id}`
       }
       if (this.value.match(/^ok_[1-9A-HJ-NP-Za-km-z]{48,50}$/)) {
         return `/oracles/queries/${this.value}`

--- a/frontend/pages/channels/_transactions/_id.vue
+++ b/frontend/pages/channels/_transactions/_id.vue
@@ -7,7 +7,7 @@
       :subpage="{to: `/channels/transactions/${$route.params.id}`, name: 'Channel Transactions'}"
     />
     <div
-      v-if="!loading && transactions.length > 0"
+      v-if="!loading && transactions && transactions.length > 0"
     >
       <TxList>
         <TXListItem
@@ -20,7 +20,7 @@
     <div v-if="loading">
       Loading....
     </div>
-    <div v-if="!loading && transactions.length == 0">
+    <div v-if="!loading && transactions && transactions.length == 0">
       Channel not found.
       Please check the channel address and try again.
     </div>

--- a/frontend/partials/contract/index.vue
+++ b/frontend/partials/contract/index.vue
@@ -34,6 +34,7 @@
       <Account
         v-if="data.hash"
         :value="data.hash"
+        :id="data.tx_index"
         title="Transaction Hash"
         icon
       />

--- a/frontend/partials/transactionDetails/index.vue
+++ b/frontend/partials/transactionDetails/index.vue
@@ -16,6 +16,7 @@
               >
                 <FormatAddress
                   :value="data.hash"
+                  :id="data.tx_index"
                   length="full"
                   icon
                 />

--- a/frontend/store/utils.js
+++ b/frontend/store/utils.js
@@ -35,7 +35,8 @@ export const transformMetaTx = (txDetails) => {
     fee: txDetails.tx.fee,
     abi_version: txDetails.tx.abi_version,
     auth_data: txDetails.tx.auth_data,
-    tx: txDetails.tx.tx.tx
+    tx: txDetails.tx.tx.tx,
+    tx_index: txDetails.tx_index
   }
 }
 


### PR DESCRIPTION
In order for search by transaction hash to work, the /tx/:hash endpoint should return transaction data.